### PR TITLE
bump image revision to 4.5.4-r1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gcr.io/stacksmith-images/ubuntu:14.04-r9
 MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_APP_NAME=kibana \
-    BITNAMI_IMAGE_VERSION=4.5.4 \
+    BITNAMI_IMAGE_VERSION=4.5.4-r1 \
     PATH=/opt/bitnami/kibana/bin:$PATH
 
 # Install kibana

--- a/README.md
+++ b/README.md
@@ -334,6 +334,14 @@ or using Docker Compose:
 ```bash
 docker-compose start kibana
 ```
+
+# Notable Changes
+
+## 4.5.4-r1
+
+- `ELASTICSEARCH_URL` parameter has been renamed to `KIBANA_ELASTICSEARCH_URL`.
+- `ELASTICSEARCH_PORT` parameter has been renamed to `KIBANA_ELASTICSEARCH_PORT`.
+
 # Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/bitnami-docker-kibana/issues), or submit a [pull request](https://github.com/bitnami/bitnami-docker-kibana/pulls) with your contribution.


### PR DESCRIPTION
- `ELASTICSEARCH_URL` parameter has been renamed to
  `KIBANA_ELASTICSEARCH_URL`.
- `ELASTICSEARCH_PORT` parameter has been renamed to
  `KIBANA_ELASTICSEARCH_PORT`.