### PR TITLE
Setting Elasticsearch to 5 series while we release Kibana 6 series

### DIFF
--- a/5/docker-compose.yml
+++ b/5/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   elasticsearch:
-    image: 'bitnami/elasticsearch:latest'
+    image: 'bitnami/elasticsearch:5'
     volumes:
       - 'elasticsearch_data:/bitnami'
   kibana:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   elasticsearch:
-    image: 'bitnami/elasticsearch:latest'
+    image: 'bitnami/elasticsearch:5'
     volumes:
       - 'elasticsearch_data:/bitnami'
   kibana:


### PR DESCRIPTION
This PR is intended to revert Elasticsearch to the 5 series in the mean time we release Kibana 6.

As soon as we have Kibana 6 series out I will change the docker-compose file from the root folder to use `latest` again.