### PR TITLE
Restore latest version of Elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   elasticsearch:
-    image: 'bitnami/elasticsearch:5'
+    image: 'bitnami/elasticsearch:latest'
     volumes:
       - 'elasticsearch_data:/bitnami'
   kibana:


### PR DESCRIPTION
Now that Kibana 6 branch has been released we can switch to use Elasticsearch 6 too.