### PR TITLE
Handle server.basePath in is_kibana_ready check

### DIFF
--- a/7.10.2/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/7.10.2/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -112,6 +112,24 @@ kibana_conf_set() {
 }
 
 ########################
+# Read a configuration setting value
+# Globals:
+#   KIBANA_*
+# Arguments:
+#   $1 - key
+# Returns:
+#   Outputs the key to stdout (Empty response if key is not set)
+#########################
+kibana_conf_get() {
+    local key="${1:?missing key}"
+
+    if [[ -r "$KIBANA_CONF_FILE" ]]; then
+        yq r "$KIBANA_CONF_FILE" "$key"
+    fi
+}
+
+
+########################
 # Configure/initialize Kibana
 # For backwards compatibility, it is allowed to specify the host and port in
 # different env-vars and this function will build the correct url.
@@ -181,7 +199,7 @@ is_kibana_not_running() {
 #   Boolean
 #########################
 is_kibana_ready() {
-    local basePath=$(yq r $KIBANA_CONF_FILE "[server.basePath]")
+    local basePath=$(kibana_conf_get "[server.basePath]")
     if is_kibana_running; then
         local -r state="$(yq r - "status.overall.state" <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath}/api/status")")"
         [[ "$state" == "green" ]]

--- a/7.10.2/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/7.10.2/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -199,7 +199,11 @@ is_kibana_not_running() {
 #   Boolean
 #########################
 is_kibana_ready() {
-    local basePath=$(kibana_conf_get "[server.basePath]")
+    local basePath=
+	local rewriteBasePath=$(kibana_conf_get "[server.rewriteBasePath]")
+	if [[ "$rewriteBasePath" == "true" ]]; then
+		basePath=$(kibana_conf_get "[server.basePath]")
+	fi
     if is_kibana_running; then
         local -r state="$(yq r - "status.overall.state" <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath}/api/status")")"
         [[ "$state" == "green" ]]

--- a/7.10.2/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/7.10.2/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -181,8 +181,9 @@ is_kibana_not_running() {
 #   Boolean
 #########################
 is_kibana_ready() {
+    local basePath=$(yq r $KIBANA_CONF_FILE "[server.basePath]")
     if is_kibana_running; then
-        local -r state="$(yq r - "status.overall.state" <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}/api/status")")"
+        local -r state="$(yq r - "status.overall.state" <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath}/api/status")")"
         [[ "$state" == "green" ]]
     else
         false

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -199,7 +199,11 @@ is_kibana_not_running() {
 #   Boolean
 #########################
 is_kibana_ready() {
-    local basePath=$(kibana_conf_get "[server.basePath]")
+    local basePath=
+	local rewriteBasePath=$(kibana_conf_get "[server.rewriteBasePath]")
+	if [[ "$rewriteBasePath" == "true" ]]; then
+		basePath=$(kibana_conf_get "[server.basePath]")
+	fi
     if is_kibana_running; then
         local -r state="$(yq r - "status.overall.state" <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath}/api/status")")"
         [[ "$state" == "green" ]]

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -112,6 +112,24 @@ kibana_conf_set() {
 }
 
 ########################
+# Read a configuration setting value
+# Globals:
+#   KIBANA_*
+# Arguments:
+#   $1 - key
+# Returns:
+#   Outputs the key to stdout (Empty response if key is not set)
+#########################
+kibana_conf_get() {
+    local key="${1:?missing key}"
+
+    if [[ -r "$KIBANA_CONF_FILE" ]]; then
+        yq r "$KIBANA_CONF_FILE" "$key"
+    fi
+}
+
+
+########################
 # Configure/initialize Kibana
 # For backwards compatibility, it is allowed to specify the host and port in
 # different env-vars and this function will build the correct url.
@@ -181,8 +199,9 @@ is_kibana_not_running() {
 #   Boolean
 #########################
 is_kibana_ready() {
+    local basePath=$(kibana_conf_get "[server.basePath]")
     if is_kibana_running; then
-        local -r state="$(yq r - "status.overall.state" <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}/api/status")")"
+        local -r state="$(yq r - "status.overall.state" <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath}/api/status")")"
         [[ "$state" == "green" ]]
     else
         false


### PR DESCRIPTION
If server.basePath is configured, it is necessary to use it when querying the API endpoint to check for successful startup.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

When polling the /api/status endpoint to determine when kibana has started, include the server.basePath if so configured.
If server.basePath is not configured no change in behavior.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Enables use of configuration.server.basePath via the bitnami/kibana helm chart to work properly.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
Add a small lookup of the server.basePath value from the yaml in the startup loop.
I considered refactoring it out, but as it is in a polling loop during startup, that
seemed to be an unnecessary optimization.

<!-- Describe any known limitations with your change -->

**Applicable issues**
Fixed only for the  latest 7.10.2 debian-10 version of the libkibana.sh script.
Same defect exists in other copies of the script for version 6 & 7.

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Verified that without server.basePath present in the kibana.yaml no change in behavior.
Tested with server.basePath present in the kibana.yaml and it now starts successfully when it previously just failed.

